### PR TITLE
Fix sub command name typo

### DIFF
--- a/cmd/downtime.go
+++ b/cmd/downtime.go
@@ -13,7 +13,7 @@ import (
 // NewCmdDowntime ...
 func NewCmdDowntime() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "monitor",
+		Use:   "downtime",
 		Short: "Display 'datadog_downtime' resource configuration",
 		Long:  `Display 'datadog_downtime' resource terraform configuration.`,
 		Args:  validations.ValidationIntArg,


### PR DESCRIPTION
<!--- Please keep this note for the community --->

### Community Note

* Please vote on this pull request by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original pull request comment to help the community and maintainers prioritize this request
* Please do not leave "+1" comments, they generate extra noise for pull request followers and do not help prioritize the request

<!--- Thank you for keeping this note for the community --->

Fixes no issue

Release note for [CHANGELOG](https://github.com/kterada0509/datadog-terraformer/blob/master/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
r/downtime fix subcommand name `monitor` -> `downtime`
```
